### PR TITLE
add depends on rosbuild, since mk does not have them, see https://github...

### DIFF
--- a/rtctree/package.xml
+++ b/rtctree/package.xml
@@ -18,6 +18,7 @@
   <build_depend>unzip</build_depend>
   <build_depend>mk</build_depend>
   <build_depend>python-omniorb</build_depend>
+  <build_depend>rosbuild</build_depend>
 
   <export/>
 

--- a/rtshell/package.xml
+++ b/rtshell/package.xml
@@ -17,6 +17,7 @@
 
   <build_depend>unzip</build_depend>
   <build_depend>mk</build_depend>
+  <build_depend>rosbuild</build_depend>
   <build_depend>rostest</build_depend>
 
   <test_depend>omniorb</test_depend>

--- a/rtsprofile/package.xml
+++ b/rtsprofile/package.xml
@@ -21,6 +21,7 @@
 
   <build_depend>unzip</build_depend>
   <build_depend>mk</build_depend>
+  <build_depend>rosbuild</build_depend>
 
   <export/>
 


### PR DESCRIPTION
....com/ros/ros/issues/47

@130s I'm not sure if this fixes the http://jenkins.ros.org/job/ros-hydro-rtsprofile_binarydeb_raring_i386/16/console problem, but it seems rosbuild is missing during install process.
