### PR TITLE
rtshell depends on rtctree/rtsprofile on running time

### DIFF
--- a/rtshell/package.xml
+++ b/rtshell/package.xml
@@ -22,5 +22,8 @@
   <build_depend>rostest</build_depend>
   <build_depend>omniorb</build_depend>
 
+  <run_depend>rtctree</run_depend>
+  <run_depend>rtsprofile</run_depend>
+
   <export/>
 </package>


### PR DESCRIPTION
curretly apt-get insatll ros-groovy-rtshell does not install rtctree, so rtshell does not run
